### PR TITLE
fix safari back-forward cache

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -16,7 +16,7 @@ $(function() {
 });
 
 // All others
-$(document).ready(function() {
+window.onpageshow(function() {
     // zoom in/zoom out animations
     if ($(".container").hasClass('fadeOut')) {
         $(".container").removeClass("fadeOut").addClass("fadeIn");


### PR DESCRIPTION
Safari - Using the back button instead of the site coded back button will cause the page to fade out entirely.